### PR TITLE
OAM-127: add additional quarantined parameter to products page

### DIFF
--- a/src/admin-orderable-list/admin-orderable-list.routes.js
+++ b/src/admin-orderable-list/admin-orderable-list.routes.js
@@ -26,7 +26,7 @@
         $stateProvider.state('openlmis.administration.orderables', {
             showInNavigation: true,
             label: 'adminOrderableList.products',
-            url: '/orderables?code&name&description&program&page&size&sort',
+            url: '/orderables?code&name&quarantined&description&program&page&size&sort',
             controller: 'OrderableListController',
             templateUrl: 'admin-orderable-list/orderable-list.html',
             controllerAs: 'vm',
@@ -41,7 +41,11 @@
                 },
                 orderables: function(paginationService, OrderableResource, $stateParams) {
                     return paginationService.registerUrl($stateParams, function(stateParams) {
-                        return new OrderableResource().query(stateParams);
+                        var params = angular.copy(stateParams);
+
+                        params.quarantined = true;
+
+                        return new OrderableResource().query(params);
                     });
                 },
                 canAdd: function(authorizationService, permissionService, ADMINISTRATION_RIGHTS) {

--- a/src/admin-orderable-list/admin-orderable-list.routes.js
+++ b/src/admin-orderable-list/admin-orderable-list.routes.js
@@ -40,10 +40,12 @@
                     return new ProgramResource().query();
                 },
                 orderables: function(paginationService, OrderableResource, $stateParams) {
-                    return paginationService.registerUrl($stateParams, function(stateParams) {
-                        var params = angular.copy(stateParams);
+                    return paginationService.registerUrl($stateParams, function() {
+                        if ($stateParams.quarantined === undefined) {
+                            $stateParams.quarantined = 'true';
+                        }
 
-                        params.quarantined = true;
+                        var params = angular.copy($stateParams);
 
                         return new OrderableResource().query(params);
                     });

--- a/src/admin-orderable-list/messages_en.json
+++ b/src/admin-orderable-list/messages_en.json
@@ -1,3 +1,4 @@
 {
-    "adminOrderableList.export": "Export"
+    "adminOrderableList.export": "Export",
+    "adminOrderableList.showQuarantined": "Show Quarantined"
 }

--- a/src/admin-orderable-list/orderable-list.controller.js
+++ b/src/admin-orderable-list/orderable-list.controller.js
@@ -62,6 +62,17 @@
         /**
          * @ngdoc property
          * @propertyOf admin-orderable-list.controller:OrderableListController
+         * @name showQuarantined
+         * @type {String}
+         * 
+         * @description
+         * Contains quarantined param for searching products.
+         */
+        vm.showQuarantined = undefined;
+
+        /**
+         * @ngdoc property
+         * @propertyOf admin-orderable-list.controller:OrderableListController
          * @name code
          * @type {String}
          *
@@ -114,9 +125,12 @@
         function onInit() {
             vm.orderables = orderables;
             vm.programs = programs;
+
+            vm.showQuarantined = $stateParams.quarantined;
             vm.code = $stateParams.code;
             vm.name = $stateParams.name;
             vm.program = $stateParams.program;
+
             vm.canAdd = canAdd;
             vm.tableConfig = getTableConfig();
         }
@@ -132,6 +146,7 @@
         function search() {
             var stateParams = angular.copy($stateParams);
 
+            stateParams.quarantined = vm.showQuarantined;
             stateParams.code = vm.code;
             stateParams.name = vm.name;
             stateParams.program = vm.program;

--- a/src/admin-orderable-list/orderable-list.html
+++ b/src/admin-orderable-list/orderable-list.html
@@ -8,6 +8,12 @@
     <button ng-if="vm.canAdd" class="add" ui-sref='.add'>{{'adminOrderableList.addProduct' | message}}</button>
     <form ng-submit="vm.search()">
         <fieldset class="form-group">
+            <label for="showQuarantined" class="checkbox">
+                <input type="checkbox" id="showQuarantined" ng-model="vm.showQuarantined" ng-true-value="'true'" ng-false-value="'false'" />
+                {{:: 'adminOrderableList.showQuarantined' | message}}
+            </label>
+        </fieldset>
+        <fieldset class="form-group">
             <label for="code">{{'adminOrderableList.code' | message}}</label>
             <input type="text" id="code" ng-model="vm.code"/>
         </fieldset>


### PR DESCRIPTION
[OAM-127](https://openlmis.atlassian.net/browse/OAM-127)

Changes:
- Add additional 'quarantined=true' parameter to products page. (Users has to see all of products, even those which are quarantined). URL: **http://localhost:9000/openlmisServer/api/orderables?page=0&quarantined=true&size=10**
- Add checkbox to the filter modal.


[OAM-127]: https://openlmis.atlassian.net/browse/OAM-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ