### PR TITLE
OAM-126: add new parameter to lots get request

### DIFF
--- a/src/admin-lot-list/admin-lot-list.routes.js
+++ b/src/admin-lot-list/admin-lot-list.routes.js
@@ -35,11 +35,14 @@
             accessRights: [ADMINISTRATION_RIGHTS.LOTS_MANAGE],
             resolve: {
                 paginatedLots: function($q, $stateParams, paginationService, lotService) {
-                    return paginationService.registerUrl($stateParams, function(stateParams) {
-                        var params = angular.copy(stateParams);
+                    return paginationService.registerUrl($stateParams, function() {
+                        if ($stateParams.quarantined === undefined) {
+                            $stateParams.quarantined = 'true';
+                        }
+
+                        var params = angular.copy($stateParams);
 
                         params.tradeItemIdIgnored = true;
-                        params.quarantined = true;
 
                         return lotService.query(params);
                     });

--- a/src/admin-lot-list/admin-lot-list.routes.js
+++ b/src/admin-lot-list/admin-lot-list.routes.js
@@ -27,7 +27,7 @@
             showInNavigation: true,
             label: 'adminLotList.lots',
             // ANGOLASUP-715: Filtering by lot code
-            url: '/lots?orderableId&expirationDateFrom&expirationDateTo&lotCode&page&size&sort',
+            url: '/lots?orderableId&quarantined&expirationDateFrom&expirationDateTo&lotCode&page&size&sort',
             // ANGOLASUP-715: Ends here
             controller: 'LotListController',
             templateUrl: 'admin-lot-list/lot-list.html',
@@ -39,6 +39,7 @@
                         var params = angular.copy(stateParams);
 
                         params.tradeItemIdIgnored = true;
+                        params.quarantined = true;
 
                         return lotService.query(params);
                     });

--- a/src/admin-lot-list/admin-lot-list.routes.spec.js
+++ b/src/admin-lot-list/admin-lot-list.routes.spec.js
@@ -119,7 +119,7 @@ describe('openlmis.administration.lot state', function() {
             size: 10,
             tradeItemIdIgnored: true,
             expirationDateFrom: '1970-01-01',
-            quarantined: true
+            quarantined: 'true'
         });
 
         expect(paginatedLots.length).toEqual(1);
@@ -141,7 +141,7 @@ describe('openlmis.administration.lot state', function() {
             size: 10,
             tradeItemIdIgnored: true,
             expirationDateTo: '1970-01-01',
-            quarantined: true
+            quarantined: 'true'
         });
 
         expect(paginatedLots.length).toEqual(1);

--- a/src/admin-lot-list/admin-lot-list.routes.spec.js
+++ b/src/admin-lot-list/admin-lot-list.routes.spec.js
@@ -1,0 +1,181 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('openlmis.administration.lot state', function() {
+
+    'use strict';
+
+    beforeEach(function() {
+        module('admin-lot-list');
+
+        inject(function($injector) {
+            this.$state = $injector.get('$state');
+            this.$location = $injector.get('$location');
+            this.$rootScope = $injector.get('$rootScope');
+            this.$q = $injector.get('$q');
+            this.$templateCache = $injector.get('$templateCache');
+            this.$stateParams = $injector.get('$stateParams');
+
+            this.orderableService = $injector.get('orderableService');
+            this.lotService = $injector.get('lotService');
+
+            this.PageDataBuilder = $injector.get('PageDataBuilder');
+            this.OrderableDataBuilder = $injector.get('OrderableDataBuilder');
+            this.LotDataBuilder = $injector.get('LotDataBuilder');
+        });
+
+        this.orderableWithTradeItem = new this.OrderableDataBuilder().build();
+        this.orderableWithTradeItem.identifiers = {
+            tradeItem: 'tradeItem'
+        };
+        this.orderables = [
+            new this.OrderableDataBuilder().build(),
+            new this.OrderableDataBuilder().build()
+        ];
+
+        spyOn(this.orderableService, 'search').andReturn(this.$q.when(
+            new this.PageDataBuilder()
+                .withContent(this.orderables)
+                .build()
+        ));
+
+        this.defaultLot = new this.LotDataBuilder().build();
+
+        spyOn(this.lotService, 'query').andReturn(this.$q.when(
+            new this.PageDataBuilder()
+                .withContent([this.defaultLot])
+                .build()
+        ));
+
+        this.$state.go('openlmis');
+        this.$rootScope.$apply();
+
+        this.goToUrl = function(url) {
+            this.$location.url(url);
+            this.$rootScope.$apply();
+        };
+
+        this.getResolvedValue = function(name) {
+            return this.$state.$current.locals.globals[name];
+        };
+    });
+
+    it('should be available under /administration/lots URL', function() {
+        expect(this.$state.current.name).not.toEqual('openlmis.administration.lots');
+
+        this.goToUrl('/administration/lots');
+
+        expect(this.$state.current.name).toEqual('openlmis.administration.lots');
+    });
+
+    it('should use html template', function() {
+        spyOn(this.$templateCache, 'get').andCallThrough();
+
+        this.goToUrl('/administration/lots');
+
+        expect(this.$templateCache.get).toHaveBeenCalledWith('admin-lot-list/lot-list.html');
+    });
+
+    it('should resolve orderables', function() {
+        this.goToUrl('/administration/lots');
+
+        expect(this.$state.current.name).toEqual('openlmis.administration.lots');
+        expect(this.getResolvedValue('orderables')).toEqual(this.orderables);
+        expect(this.orderableService.search).toHaveBeenCalled();
+    });
+
+    it('should resolve non-empty paginatedLots when orderableId filter is empty ', function() {
+        this.goToUrl('/administration/lots');
+
+        var paginatedLots = this.getResolvedValue('paginatedLots');
+
+        expect(paginatedLots.length).toNotEqual(0);
+    });
+
+    it('should resolve non-empty paginatedLots when expirationDateFrom filter is set ', function() {
+        var lot = new this.LotDataBuilder().build();
+        this.lotService.query.andReturn(this.$q.when({
+            content: [lot]
+        }));
+
+        this.goToUrl('/administration/lots?expirationDateFrom=1970-01-01');
+
+        var paginatedLots = this.getResolvedValue('paginatedLots');
+
+        expect(this.lotService.query).toHaveBeenCalledWith({
+            page: 0,
+            size: 10,
+            tradeItemIdIgnored: true,
+            expirationDateFrom: '1970-01-01',
+            quarantined: true
+        });
+
+        expect(paginatedLots.length).toEqual(1);
+        expect(paginatedLots[0]).toEqual(lot);
+    });
+
+    it('should resolve non-empty paginatedLots when expirationDateTo filter is set ', function() {
+        var lot = new this.LotDataBuilder().build();
+        this.lotService.query.andReturn(this.$q.when({
+            content: [lot]
+        }));
+
+        this.goToUrl('/administration/lots?expirationDateTo=1970-01-01');
+
+        var paginatedLots = this.getResolvedValue('paginatedLots');
+
+        expect(this.lotService.query).toHaveBeenCalledWith({
+            page: 0,
+            size: 10,
+            tradeItemIdIgnored: true,
+            expirationDateTo: '1970-01-01',
+            quarantined: true
+        });
+
+        expect(paginatedLots.length).toEqual(1);
+
+        expect(paginatedLots[0]).toEqual(lot);
+    });
+
+    it('should resolve lots ', function() {
+        var orderableWithTradeItem = new this.OrderableDataBuilder().build();
+        orderableWithTradeItem.identifiers = {
+            tradeItem: 'tradeItem'
+        };
+
+        this.orderableService.search.andReturn(this.$q.when(
+            new this.PageDataBuilder()
+                .withContent([orderableWithTradeItem])
+                .build()
+        ));
+
+        var lotWithMatchingOrderable = new this.LotDataBuilder().build();
+        lotWithMatchingOrderable.tradeItemId = 'tradeItem';
+
+        this.lotService.query.andReturn(this.$q.when({
+            content: [
+                lotWithMatchingOrderable,
+                new this.LotDataBuilder().build()
+            ]
+        }));
+
+        this.goToUrl('/administration/lots');
+
+        var lots = this.getResolvedValue('lots');
+
+        expect(lots.length).toEqual(2);
+    });
+
+});

--- a/src/admin-lot-list/lot-list.controller.js
+++ b/src/admin-lot-list/lot-list.controller.js
@@ -101,12 +101,10 @@
          * @ngdoc property
          * @propertyOf admin-lot-list.controller:LotListController
          * @name showQuarantined
-         * @type {Boolean}
+         * @type {String}
          * 
          * @description
-         * Flag to show quarantined lots
-         * When set to true, quarantined lots are visible
-         * When set to false, quarantined lots are not visible
+         * Indicates if quarantined lots should be visible
          */
         vm.showQuarantined = undefined;
 

--- a/src/admin-lot-list/lot-list.controller.js
+++ b/src/admin-lot-list/lot-list.controller.js
@@ -100,6 +100,19 @@
         /**
          * @ngdoc property
          * @propertyOf admin-lot-list.controller:LotListController
+         * @name showQuarantined
+         * @type {Boolean}
+         * 
+         * @description
+         * Flag to show quarantined lots
+         * When set to true, quarantined lots are visible
+         * When set to false, quarantined lots are not visible
+         */
+        vm.showQuarantined = undefined;
+
+        /**
+         * @ngdoc property
+         * @propertyOf admin-lot-list.controller:LotListController
          * @name tableConfig
          * @type {Object}
          */
@@ -119,6 +132,7 @@
             stateParams.orderableId = vm.orderableId;
             stateParams.expirationDateFrom = vm.expirationDateFrom;
             stateParams.expirationDateTo = vm.expirationDateTo;
+            stateParams.quarantined = vm.showQuarantined;
             // ANGOLASUP-715: Filtering by lot code
             stateParams.lotCode = vm.lotCode;
             // ANGOLASUP-715: Ends here
@@ -140,9 +154,11 @@
             vm.lots = lots;
             vm.orderables = orderables;
 
+            vm.showQuarantined = $stateParams.quarantined;
             vm.orderableId = $stateParams.orderableId;
             vm.expirationDateFrom = $stateParams.expirationDateFrom;
             vm.expirationDateTo = $stateParams.expirationDateTo;
+
             // ANGOLASUP-715: Filtering by lot code
             vm.lotCode = $stateParams.lotCode;
             // ANGOLASUP-715: Ends here

--- a/src/admin-lot-list/lot-list.html
+++ b/src/admin-lot-list/lot-list.html
@@ -2,6 +2,12 @@
 <section class="openlmis-table-container">
     <form ng-submit="vm.search()">
         <fieldset class="form-group">
+            <label for="showQuarantined" class="checkbox">
+                <input type="checkbox" id="showQuarantined" ng-model="vm.showQuarantined" ng-true-value="'true'" ng-false-value="'false'" />
+                {{:: 'adminLotList.showQuarantined' | message}}
+            </label>
+        </fieldset>
+        <fieldset class="form-group">
             <label for="expirationDateFrom">{{'adminLotList.expirationDateFrom' | message}}</label>
             <input type="date" id="expirationDateFrom" ng-model="vm.expirationDateFrom"/>
         </fieldset>

--- a/src/admin-lot-list/messages_en.json
+++ b/src/admin-lot-list/messages_en.json
@@ -1,0 +1,16 @@
+{
+    "adminLotList.lots": "Lots",
+    "adminLotList.expirationDateFrom": "Earliest Expiry Date",
+    "adminLotList.expirationDateTo": "Latest Expiry Date",
+    "adminLotList.product": "Product",
+    "adminLotList.search": "Search",
+    "adminLotList.noLots": "No lots found.",
+    "adminLotList.productCode": "Product Code",
+    "adminLotList.productName": "Product Name",
+    "adminLotList.lotCode": "Lot Code",
+    "adminLotList.expirationDate": "Expiry date",
+    "adminLotList.manufacturedDate": "Manufacture Date",
+    "adminLotList.actions": "Actions",
+    "adminLotList.edit": "Edit",
+    "adminLotList.showQuarantined": "Show Quarantined"
+}

--- a/src/openlmis-i18n/message.service.js
+++ b/src/openlmis-i18n/message.service.js
@@ -140,6 +140,7 @@
                 }
 
             } else {
+                // eslint-disable-next-line no-console
                 console.error('[ERROR]: Translation message not found for: ' + key);
             }
 


### PR DESCRIPTION
[OAM-126](https://openlmis.atlassian.net/browse/OAM-126)

Changes:
- Add additional 'quarantined=true' parameter to lots page. (Users has to see all of lots, even those which are quarantined). URL: **http://localhost:9000/openlmisServer/api/lots?page=0&quarantined=true&size=10&tradeItemIdIgnored=true**
- Add new checkbox which will allow to filter out quarantined lots.
- Fix eslint error.
- Fix tests.


[OAM-126]: https://openlmis.atlassian.net/browse/OAM-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ