### PR TITLE
OAM-127: show quarantined by default, add checkbox to hide quarantined

### DIFF
--- a/src/admin-orderable-list/admin-orderable-list.routes.js
+++ b/src/admin-orderable-list/admin-orderable-list.routes.js
@@ -26,7 +26,7 @@
         $stateProvider.state('openlmis.administration.orderables', {
             showInNavigation: true,
             label: 'adminOrderableList.products',
-            url: '/orderables?code&name&description&program&page&size&sort',
+            url: '/orderables?code&includeQuarantined&name&description&program&page&size&sort',
             controller: 'OrderableListController',
             templateUrl: 'admin-orderable-list/orderable-list.html',
             controllerAs: 'vm',
@@ -40,8 +40,12 @@
                     return new ProgramResource().query();
                 },
                 orderables: function(paginationService, OrderableResource, $stateParams) {
-                    return paginationService.registerUrl($stateParams, function(stateParams) {
-                        return new OrderableResource().query(stateParams);
+                    return paginationService.registerUrl($stateParams, function() {
+                        if (!$stateParams.includeQuarantined && $stateParams.includeQuarantined !== 'false') {
+                            $stateParams.includeQuarantined = 'true';
+                        }
+
+                        return new OrderableResource().query($stateParams);
                     });
                 },
                 canAdd: function(authorizationService, permissionService, ADMINISTRATION_RIGHTS) {

--- a/src/admin-orderable-list/messages_en.json
+++ b/src/admin-orderable-list/messages_en.json
@@ -1,5 +1,5 @@
 {
     "adminOrderableList.export": "Export",
-    "adminOrderableList.showQuarantined": "Show Quarantined",
+    "adminOrderableList.includeQuarantined": "Include Quarantined Products",
     "adminOrderableList.isQuarantined": "Quarantined"
 }

--- a/src/admin-orderable-list/orderable-list.controller.js
+++ b/src/admin-orderable-list/orderable-list.controller.js
@@ -62,6 +62,16 @@
         /**
          * @ngdoc property
          * @propertyOf admin-orderable-list.controller:OrderableListController
+         * @name includeQuarantined
+         * 
+         * @description
+         * Contains flag for including quarantined orderables. By default, quarantined products are listed.
+         */
+        vm.includeQuarantined = undefined;
+
+        /**
+         * @ngdoc property
+         * @propertyOf admin-orderable-list.controller:OrderableListController
          * @name code
          * @type {String}
          *
@@ -118,6 +128,7 @@
             vm.code = $stateParams.code;
             vm.name = $stateParams.name;
             vm.program = $stateParams.program;
+            vm.includeQuarantined = $stateParams.includeQuarantined;
 
             vm.canAdd = canAdd;
             vm.tableConfig = getTableConfig();
@@ -137,6 +148,7 @@
             stateParams.code = vm.code;
             stateParams.name = vm.name;
             stateParams.program = vm.program;
+            stateParams.includeQuarantined = vm.includeQuarantined;
 
             $state.go('openlmis.administration.orderables', stateParams, {
                 reload: true

--- a/src/admin-orderable-list/orderable-list.html
+++ b/src/admin-orderable-list/orderable-list.html
@@ -22,6 +22,12 @@
                     ng-model="vm.program">
             </select>
         </fieldset>
+        <fieldset class="form-group">
+            <label for="includeQuarantined" class="checkbox">
+                <input type="checkbox" id="includeQuarantined" ng-model="vm.includeQuarantined" ng-true-value="'true'" ng-false-value="'false'" />
+                {{:: 'adminOrderableList.includeQuarantined' | message}}
+            </label>
+        </fieldset>
         <input type="submit" value="{{'adminOrderableList.search' | message}}"/>
     </form>
     <openlmis-table table-config="vm.tableConfig"></openlmis-table>


### PR DESCRIPTION
[OAM-127](https://openlmis.atlassian.net/browse/OAM-127)

Changes:
- Show quarantined products when entering 'Products' page.
- Add checkbox to control whether quarantined products should be displayed or not.

[OAM-127]: https://openlmis.atlassian.net/browse/OAM-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ