### PR TITLE
OAM-126: return quarantined lots on initial fetch, add filter

### DIFF
--- a/src/admin-lot-list/admin-lot-list.routes.js
+++ b/src/admin-lot-list/admin-lot-list.routes.js
@@ -26,15 +26,17 @@
         $stateProvider.state('openlmis.administration.lots', {
             showInNavigation: true,
             label: 'adminLotList.lots',
-            // ANGOLASUP-715: Filtering by lot code
-            url: '/lots?orderableId&expirationDateFrom&expirationDateTo&lotCode&page&size&sort',
-            // ANGOLASUP-715: Ends here
+            url: '/lots?orderableId&includeQuarantined&expirationDateFrom&expirationDateTo&lotCode&page&size&sort',
             controller: 'LotListController',
             templateUrl: 'admin-lot-list/lot-list.html',
             controllerAs: 'vm',
             accessRights: [ADMINISTRATION_RIGHTS.LOTS_MANAGE],
             resolve: {
                 paginatedLots: function($q, $stateParams, paginationService, lotService) {
+                    if (!$stateParams.includeQuarantined && $stateParams.includeQuarantined !== 'false') {
+                        $stateParams.includeQuarantined = 'true';
+                    }
+
                     return paginationService.registerUrl($stateParams, function(stateParams) {
                         var params = angular.copy(stateParams);
 

--- a/src/admin-lot-list/admin-lot-list.routes.spec.js
+++ b/src/admin-lot-list/admin-lot-list.routes.spec.js
@@ -118,7 +118,8 @@ describe('openlmis.administration.lot state', function() {
             page: 0,
             size: 10,
             tradeItemIdIgnored: true,
-            expirationDateFrom: '1970-01-01'
+            expirationDateFrom: '1970-01-01',
+            includeQuarantined: 'true'
         });
 
         expect(paginatedLots.length).toEqual(1);
@@ -139,7 +140,8 @@ describe('openlmis.administration.lot state', function() {
             page: 0,
             size: 10,
             tradeItemIdIgnored: true,
-            expirationDateTo: '1970-01-01'
+            expirationDateTo: '1970-01-01',
+            includeQuarantined: 'true'
         });
 
         expect(paginatedLots.length).toEqual(1);

--- a/src/admin-lot-list/lot-list.controller.js
+++ b/src/admin-lot-list/lot-list.controller.js
@@ -60,6 +60,16 @@
         /**
          * @ngdoc property
          * @propertyOf admin-lot-list.controller:LotListController
+         * @name includeQuarantined
+         * 
+         * @description
+         * Include quarantined lots in the list. By default, quarantined lots are included.
+         */
+        vm.includeQuarantined = undefined;
+
+        /**
+         * @ngdoc property
+         * @propertyOf admin-lot-list.controller:LotListController
          * @name orderableId
          * @type {String}
          *
@@ -116,6 +126,7 @@
         vm.search = function() {
             var stateParams = angular.copy($stateParams);
 
+            stateParams.includeQuarantined = vm.includeQuarantined;
             stateParams.orderableId = vm.orderableId;
             stateParams.expirationDateFrom = vm.expirationDateFrom;
             stateParams.expirationDateTo = vm.expirationDateTo;
@@ -140,6 +151,7 @@
             vm.lots = lots;
             vm.orderables = orderables;
 
+            vm.includeQuarantined = $stateParams.includeQuarantined;
             vm.orderableId = $stateParams.orderableId;
             vm.expirationDateFrom = $stateParams.expirationDateFrom;
             vm.expirationDateTo = $stateParams.expirationDateTo;

--- a/src/admin-lot-list/lot-list.html
+++ b/src/admin-lot-list/lot-list.html
@@ -22,6 +22,18 @@
             <input type="text" id="lotCode" ng-model="vm.lotCode"/>
         </fieldset>
         <!-- ANGOLASUP-715: Ends here -->
+        <fieldset class="form-group">
+            <label for="includeQuarantined" class="checkbox">
+                <input 
+                    type="checkbox"
+                    id="includeQuarantined"
+                    ng-model="vm.includeQuarantined"
+                    ng-true-value="'true'"
+                    ng-false-value="'false'"
+                />
+                {{:: 'adminLotList.includeQuarantined' | message}}
+            </label>
+        </fieldset>
         <input type="submit" value="{{'adminLotList.search' | message}}"/>
     </form>
     <openlmis-table table-config="vm.tableConfig"></openlmis-table>

--- a/src/admin-lot-list/messages_en.json
+++ b/src/admin-lot-list/messages_en.json
@@ -12,6 +12,6 @@
     "adminLotList.manufacturedDate": "Manufacture Date",
     "adminLotList.actions": "Actions",
     "adminLotList.edit": "Edit",
-    "adminLotList.showQuarantined": "Show Quarantined",
+    "adminLotList.includeQuarantined": "Include Quarantined Lots",
     "adminLotList.isQuarantined": "Quarantined"
 }


### PR DESCRIPTION
[OAM-126](https://openlmis.atlassian.net/browse/OAM-126)

Changes:
- Include quarantined lots in the list when user enters the Lots page initially.
- Add checkbox to control whether quarantined lots should be included or not.

[OAM-126]: https://openlmis.atlassian.net/browse/OAM-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ