### PR TITLE
OAM-209: set approvedQuantity to 0 if product quarantined

### DIFF
--- a/src/requisition-constants/template-columns.constant.js
+++ b/src/requisition-constants/template-columns.constant.js
@@ -75,7 +75,8 @@
         function getColumnsToBeBlockedIfQuarantined() {
             return [
                 this.REQUESTED_QUANTITY_EXPLANATION,
-                this.REQUESTED_QUANTITY
+                this.REQUESTED_QUANTITY,
+                this.APPROVED_QUANTITY
             ];
         }
     }

--- a/src/requisition-constants/template-columns.constant.spec.js
+++ b/src/requisition-constants/template-columns.constant.spec.js
@@ -48,6 +48,7 @@ describe('TEMPLATE_COLUMNS', function() {
 
             expect(listOfColumns[0]).toEqual('requestedQuantityExplanation');
             expect(listOfColumns[1]).toEqual('requestedQuantity');
+            expect(listOfColumns[2]).toEqual('approvedQuantity');
         });
     });
 });

--- a/src/requisition/line-item.js
+++ b/src/requisition/line-item.js
@@ -28,9 +28,9 @@
         .module('requisition')
         .factory('LineItem', lineItem);
 
-    lineItem.$inject = ['calculationFactory', 'COLUMN_SOURCES', 'COLUMN_TYPES', 'messageService'];
+    lineItem.$inject = ['calculationFactory', 'COLUMN_SOURCES', 'COLUMN_TYPES', 'TEMPLATE_COLUMNS', 'messageService'];
 
-    function lineItem(calculationFactory, COLUMN_SOURCES, COLUMN_TYPES, messageService) {
+    function lineItem(calculationFactory, COLUMN_SOURCES, COLUMN_TYPES, TEMPLATE_COLUMNS, messageService) {
 
         LineItem.prototype.getFieldValue = getFieldValue;
         LineItem.prototype.updateFieldValue = updateFieldValue;
@@ -109,6 +109,14 @@
                         calculationFactory[fullName](this, requisition) :
                         null;
                 } else if (column.$type === COLUMN_TYPES.NUMERIC || column.$type === COLUMN_TYPES.CURRENCY) {
+                    if (
+                        Boolean(object.orderable.quarantined) &&
+                        fullName === TEMPLATE_COLUMNS.APPROVED_QUANTITY
+                    ) {
+                        // If the orderable is quarantined, the approved quantity must be 0
+                        object[propertyName] = 0;
+                    }
+
                     checkIfNullOrZero(object[propertyName]);
                 } else {
                     object[propertyName] = object[propertyName] ? object[propertyName] : '';


### PR DESCRIPTION
[OAM-209](https://openlmis.atlassian.net/browse/OAM-209)

Changes:
- If product is under quarantine, approved quantity in Approve stage has to be set to 0.

[OAM-209]: https://openlmis.atlassian.net/browse/OAM-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ