### PR TITLE
OAM-38: Added missing actionType to proof of delivery table

### DIFF
--- a/src/proof-of-delivery-manage/proof-of-delivery-manage.controller.js
+++ b/src/proof-of-delivery-manage/proof-of-delivery-manage.controller.js
@@ -315,7 +315,7 @@
                     classes: 'col-sticky sticky-right',
                     data: [
                         {
-                            type: TABLE_CONSTANTS.CLICK,
+                            type: TABLE_CONSTANTS.actionTypes.CLICK,
                             text: 'proofOfDeliveryManage.manage',
                             classes: 'primary',
                             onClick: function(item) {
@@ -323,7 +323,7 @@
                             }
                         },
                         {
-                            type: TABLE_CONSTANTS.CLICK,
+                            type: TABLE_CONSTANTS.actionTypes.CLICK,
                             text: 'proofOfDeliveryManage.print',
                             onClick: function(item) {
                                 vm.printProofOfDelivery(item.id);


### PR DESCRIPTION
There was no actions displayed in order proof of delivery. Added missing types to actions in order to fix that